### PR TITLE
Update alpine and aws-cli to current latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Alpine 3.7 is current latest
-FROM alpine:3.7
+# Alpine 3.8 is current latest
+FROM alpine:3.8
 
-ENV AWS_CLI_VERSION=1.15.40
+ENV AWS_CLI_VERSION=1.16.83
 
 RUN apk --update --no-cache add \
     python \


### PR DESCRIPTION
This PR updates the Alpine and AWS CLI versions to the current latest.

Alpine: **3.8** (https://hub.docker.com/_/alpine/)
AWS CLI: **1.16.83** (https://github.com/aws/aws-cli/releases)