### PR TITLE
Add installation for groff & less to fix aws cli dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apk --update --no-cache add \
     curl \
     nodejs \
     nodejs-npm \
+    groff \
+    less \
     && pip install --no-cache-dir awscli==$AWS_CLI_VERSION \
     && npm install -g yarn \
     && apk del py-pip \


### PR DESCRIPTION
This PR brings a fix to the installation and dependencies of the AWS CLI. Currently if you rely on the current image and you try to use the AWS CLI in any way, you will get the following error message:

```
bash-4.4# aws help

Could not find executable named "groff"
bash-4.4#`
```

This seems to be a known issue (https://github.com/aws/aws-cli/issues/1957#issuecomment-444307537) for which the fix is simply to add `groff` and `less` to the installation package. After adding these, the image was rebuilt locally and the problem seems to be fixed. 